### PR TITLE
Addition of two properties for aside heading

### DIFF
--- a/src/cv.typ
+++ b/src/cv.typ
@@ -52,18 +52,19 @@
 
           let left-over-space = th("aside-width") - th("margin") - size.width
           let gap = th("aside-heading-line-gap")
+          let opposite-gap = th("aside-heading-line-opposite-gap")
 
           let stroke-line = (
             paint: th("aside-heading-text").fill,
             thickness: th("aside-heading-line-thickness"),
-            cap: "butt",
+            cap: th("aside-heading-line-cap"),
           )
           let stroke-line-end = (
             paint: th("aside-heading-text").fill,
             thickness: th("aside-heading-line-thickness"),
-            cap: "round",
+            cap: th("aside-heading-line-cap"),
           )
-          let _line = line(start: (gap, 0%), length: left-over-space - gap, stroke: stroke-line)
+          let _line = line(start: (gap, 0%), length: left-over-space - gap - opposite-gap, stroke: stroke-line)
           let _boxed-line = box(_line, height: size.height)
           let _line2 = line(start: (gap, 0%), length: 0pt, stroke: stroke-line-end)
           let _boxed-line2 = box(_line2, height: size.height)

--- a/src/cv.typ
+++ b/src/cv.typ
@@ -66,8 +66,12 @@
           )
           let _line = line(start: (gap, 0%), length: left-over-space - gap - opposite-gap, stroke: stroke-line)
           let _boxed-line = box(_line, height: size.height)
+          let _line2 = line(start: (gap, 0%), length: 0pt, stroke: stroke-line-end)
+          let _boxed-line2 = box(_line2, height: size.height)
 
-          align(_boxed-line, horizon)
+          // let _line = align(box(line(length: left-over-space), height: size.height), horizon)
+          align(_boxed-line + _boxed-line2, horizon)
+          // [#_line]
         }, width: 0pt)
       } else {
         it

--- a/src/cv.typ
+++ b/src/cv.typ
@@ -62,7 +62,7 @@
           let stroke-line-end = (
             paint: th("aside-heading-text").fill,
             thickness: th("aside-heading-line-thickness"),
-            cap: th("aside-heading-line-cap"),
+            cap: th("aside-heading-line-opposite-cap"),
           )
           let _line = line(start: (gap, 0%), length: left-over-space - gap - opposite-gap, stroke: stroke-line)
           let _boxed-line = box(_line, height: size.height)

--- a/src/cv.typ
+++ b/src/cv.typ
@@ -66,12 +66,8 @@
           )
           let _line = line(start: (gap, 0%), length: left-over-space - gap - opposite-gap, stroke: stroke-line)
           let _boxed-line = box(_line, height: size.height)
-          let _line2 = line(start: (gap, 0%), length: 0pt, stroke: stroke-line-end)
-          let _boxed-line2 = box(_line2, height: size.height)
 
-          // let _line = align(box(line(length: left-over-space), height: size.height), horizon)
-          align(_boxed-line + _boxed-line2, horizon)
-          // [#_line]
+          align(_boxed-line, horizon)
         }, width: 0pt)
       } else {
         it

--- a/src/themes/forty-seconds.typ
+++ b/src/themes/forty-seconds.typ
@@ -83,7 +83,9 @@
   ),
   aside-heading-line-enable: true,
   aside-heading-line-gap: 10pt,
+  aside-heading-line-opposite-gap: 10pt,
   aside-heading-line-thickness: 1pt,
+  aside-heading-line-cap: "round",
 
   aside-pill-box-inner: (
     fill: _aside-background-color.lighten(75%),

--- a/template/theme.typ
+++ b/template/theme.typ
@@ -83,7 +83,7 @@
   ),
   aside-heading-line-enable: true,
   aside-heading-line-gap: 10pt,
-  aside-heading-line-opposite-gap: 10pt,
+  aside-heading-line-opposite-gap: 0pt,
   aside-heading-line-thickness: 1pt,
   aside-heading-line-cap: "round",
 

--- a/template/theme.typ
+++ b/template/theme.typ
@@ -85,8 +85,8 @@
   aside-heading-line-gap: 10pt,
   aside-heading-line-opposite-gap: 0pt,
   aside-heading-line-thickness: 1pt,
-  aside-heading-line-cap: "round",
-  aside-heading-line-opposite-cap: "round",
+  aside-heading-line-cap: "butt",
+  aside-heading-line-opposite-cap: "butt",
 
   aside-pill-box-inner: (
     fill: _aside-background-color.lighten(75%),

--- a/template/theme.typ
+++ b/template/theme.typ
@@ -83,7 +83,9 @@
   ),
   aside-heading-line-enable: true,
   aside-heading-line-gap: 10pt,
+  aside-heading-line-opposite-gap: 10pt,
   aside-heading-line-thickness: 1pt,
+  aside-heading-line-cap: "round",
 
   aside-pill-box-inner: (
     fill: _aside-background-color.lighten(75%),

--- a/template/theme.typ
+++ b/template/theme.typ
@@ -86,6 +86,7 @@
   aside-heading-line-opposite-gap: 0pt,
   aside-heading-line-thickness: 1pt,
   aside-heading-line-cap: "round",
+  aside-heading-line-opposite-cap: "round",
 
   aside-pill-box-inner: (
     fill: _aside-background-color.lighten(75%),


### PR DESCRIPTION
**Changes:**

- Addition of two properties `aside-heading-line-opposite-gap` with default *10pt* and `aside-heading-line-cap` with default *"round"*
- Removal of unnecessary code for `_line2` and `_boxed-line2` and some comments.